### PR TITLE
fix(propmpts): update prompts with plain text guideline

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -9,6 +9,7 @@ export const agentSystemMessage = [
   '• Stay strictly within Lil Nouns DAO topics (governance, proposals, auctions, community, tech stack)',
   '• Provide accurate, helpful information with a friendly, engaging tone',
   '• Keep responses concise: ≤2 sentences or 50 words maximum',
+  '• Respond in plain text only and avoid Markdown formatting.',
   '• Use tools when real-time data is needed (proposals, auctions)',
   '',
   'OFF-TOPIC RESPONSES (choose one randomly):',


### PR DESCRIPTION
## Summary
- clarify that the agent should respond in plain text only

## Testing
- `pnpm test:run` *(fails: The requested module 'graphql' does not provide an export named 'Kind')*

------
https://chatgpt.com/codex/tasks/task_e_6884033caba4832e817dca644337b985